### PR TITLE
Minimalist version of docs build with sphinx

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,27 +8,19 @@ jobs:
       # Checkout and build the docs with sphinx
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e . '.[docs]'
       - name: Build HTML
         uses: ammaraskar/sphinx-action@7.4.7
         with: 
           docs-folder: "docs/"
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: html-docs
             path: docs/build/html/
         # Deploys to the gh-pages branch if the commit was made to main, the 
         # gh-pages then takes over serving the html
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: github.ref == 'refs/heads/main'
         with:
             github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,14 @@ jobs:
       # Checkout and build the docs with sphinx
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . '.[docs]'
       - name: Build HTML
         uses: ammaraskar/sphinx-action@7.4.7
         with: 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       # Checkout and build the docs with sphinx
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build HTML
-        uses: ammaraskar/sphinx-action@master
+        uses: ammaraskar/sphinx-action@7.4.7
         with: 
           docs-folder: "docs/"
       - name: Upload artifacts

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,6 @@
+# Github action to build docs and, if on main, deploy to the gh-pages branch
 name: docs
-
-on:
-  push:
-    branches: [ "main", "development" ]
-  pull_request:
-    branches: [ "main", "development" ]
-
+on: [push, pull_request]
 jobs:
   sphinx:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/atlasapiclient/__init__.py
+++ b/atlasapiclient/__init__.py
@@ -1,1 +1,6 @@
+import importlib.metadata
+
 from . import client, exceptions, utils
+
+
+__version__ = importlib.metadata.version(__package__ or __name__)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==7.4.7
-sphinx_rtd_theme==3.0.2
+-e .[docs]
+-e .

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -1,0 +1,19 @@
+ATLAS API Client Reference
+==========================
+
+
+The client module
+-----------------
+
+.. automodule:: atlasapiclient.client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+The exceptions module
+---------------------
+
+.. automodule:: atlasapiclient.exceptions
+    :members:
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../../'))
 
+import atlasapiclient
 from atlasapiclient import __version__
 
 # -- General configuration ---------------------------------------------------
@@ -23,11 +24,11 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
 ]
+# The full version, including alpha/beta/rc tags
+release = __version__
 
 templates_path = ['_templates']
 exclude_patterns = []
-
-
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,12 +6,13 @@
 ATLAS API Client documentation
 ==============================
 
-Add your content using ``reStructuredText`` syntax. See the
-`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
-documentation for details.
+This is the documentation for the ATLAS API Client package. This provides a
+convenient way to interact with the ATLAS Transient Server REST-API via Python.
 
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+   :maxdepth: 1
+   :caption: Contents
+
+   API Reference <api-reference>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ markers = [
 
 [project.optional-dependencies]
 test = ["pytest"]  
-docs = ["sphinx==7.4.7", "sphinx_rtd_theme==3.0.1"]                                                                                           
+docs = ["sphinx==7.4.7", "sphinx_rtd_theme==3.0.2"]                                                                                           
                                                                              
                                                                                                                              
 #[project.scripts]                                                                                                           


### PR DESCRIPTION
This is a minimalist version of a working docs build-and-deploy workflow using sphinx and github actions. Will attempt to build the documentation found in the `docs/` directory and then push it to gh-pages for serving. 

Note @HeloiseS I can't currently access the settings to make sure that gh-pages is serving from the correct place, please assist if necessary