### PR TITLE
Add automatic token refreshment 

### DIFF
--- a/atlasapiclient/authentication.py
+++ b/atlasapiclient/authentication.py
@@ -3,6 +3,7 @@ import getpass
 import requests
 
 from .exceptions import ATLASAPIClientAuthError
+from .utils import validate_url
 
 REFRESH_STATEMENT = """
 Your token has expired, now attempting to automatically refresh it.
@@ -62,13 +63,17 @@ class Token():
         return token
         
     def validate(self) -> str:
-       return self._validate(self.val)
+       self.val = self._validate(self.val)
    
     def refresh(self, base_url: str) -> str:
         """
         Refresh the token using the API endpoint 'auth-token/'. Requires getting
         the username and password from the user and vetting the output 
         """
+        # NOTE: Should we validate this url?
+        if not isinstance(base_url, str):
+            raise ATLASAPIClientAuthError("Base URL must be a string")
+        base_url = validate_url(base_url)
         auth_url = base_url + 'auth-token/'
         
         print(REFRESH_STATEMENT.format(url=auth_url)) 

--- a/atlasapiclient/authentication.py
+++ b/atlasapiclient/authentication.py
@@ -1,0 +1,110 @@
+import getpass
+
+import requests
+
+from .exceptions import ATLASAPIClientAuthError
+
+REFRESH_STATEMENT = """
+Your token has expired, now attempting to automatically refresh it.
+
+
+You will need to enter your username and password to refresh your 
+token. These will not be stored or saved anywhere, but if you do not 
+wish to enter them here, you can refresh your token manually at the 
+endpoint:
+    
+    {url}
+
+or request a member of staff to do so on your behalf.
+
+"""
+
+class Token():
+    def __init__(self, token_str):
+        self.val = self._validate(token_str)        
+    
+    def __repr__(self):
+        return f"Token({self.val})"
+    
+    def __str__(self):
+        return self.val
+    
+    def as_auth_header(self):
+        return f"Token {self.val}"
+    
+    def as_bearer_header(self):
+        return f"Bearer {self.val}"
+    
+    def as_query_param(self):
+        return str(self)
+    
+    def as_cookie(self):
+        return self.as_dict()
+    
+    def as_dict(self):
+        return {"token": self.val}
+        
+    @staticmethod
+    def _validate(token: str) -> str:
+        """
+        Check that the token is valid - it must be a string
+        
+        :param token: string containing the token
+        :return: str representing the token
+        
+        :raises: ATLASAPIClientError: if the token is not a valid string
+        """
+        if not token or not isinstance(token, str):
+            raise ATLASAPIClientAuthError("Candidate token must be a string")
+        elif len(token) != 40:
+            raise ATLASAPIClientAuthError("Candidate token must be 40 characters long")
+
+        return token
+        
+    def validate(self) -> str:
+       return self._validate(self.val)
+   
+    def refresh(self, base_url: str) -> str:
+        """
+        Refresh the token using the API endpoint 'auth-token/'. Requires getting
+        the username and password from the user and vetting the output 
+        """
+        auth_url = base_url + 'auth-token/'
+        
+        print(REFRESH_STATEMENT.format(url=auth_url)) 
+        username, password = self.get_username_password()
+        refresh_payload = {"password": password, "username": username}
+        
+        response = requests.post(auth_url, refresh_payload)
+
+        if response.status_code == 200:
+            response_data = response.json()
+            if 'token' not in response_data:
+                raise ATLASAPIClientAuthError("Failed to refresh token, response does not contain a token")
+            # Validate then update the stored token
+            self.val = self._validate(response_data['token'])
+            
+        elif response.status_code == 400:
+            response_data = response.json()
+            if 'non_field_errors' in response_data:
+                raise ATLASAPIClientAuthError(f"Failed to refresh token: {response_data['non_field_errors']}")
+            elif 'username' in response_data:
+                raise ATLASAPIClientAuthError(f"Failed to refresh token: no username was provided")
+            elif 'password' in response_data:
+                raise ATLASAPIClientAuthError(f"Failed to refresh token: no password was provided")
+            else:
+                raise ATLASAPIClientAuthError(f"Failed to refresh token, unspecified 400 error {response_data}")
+        else:
+            raise ATLASAPIClientAuthError(f"Failed to refresh token, error encountered: {response.json()}")
+        
+    @staticmethod
+    def get_username_password() -> tuple:
+        """
+        Get the username and password as text input from the user
+        
+        :return: tuple containing the username and password
+        """
+        username = input("Please enter your username: ")
+        password = getpass.getpass(f"Please enter password for {username}: ")
+        
+        return username, password

--- a/atlasapiclient/client.py
+++ b/atlasapiclient/client.py
@@ -27,7 +27,7 @@ from tqdm import tqdm
 import pandas as pd
 
 from atlasapiclient.exceptions import ATLASAPIClientError
-from atlasapiclient.utils import dict_list_id, API_CONFIG_FILE
+from atlasapiclient.utils import dict_list_id, API_CONFIG_FILE, get_url
 
 
 class APIClient(ABC):
@@ -87,7 +87,7 @@ class APIClient(ABC):
             raise ATLASAPIClientError(f"Error parsing YAML file: {e}")
 
         self.headers = {'Authorization': f"Token {config['token']}"}  # Set the headers with my private token
-        self.apiURL = config['base_url']  # Set the base of the url (the same for all requests)
+        self.apiURL = get_url(config['base_url'])  # Set the base of the url (the same for all requests)
         # -> directs to the ATLAS transient web server
     
     def parse_atlas_id(self, atlas_id: str) -> int:

--- a/atlasapiclient/client.py
+++ b/atlasapiclient/client.py
@@ -29,7 +29,7 @@ from atlasapiclient.exceptions import ATLASAPIClientError
 from atlasapiclient.utils import (
     dict_list_id, 
     API_CONFIG_FILE, 
-    get_url,  
+    validate_url,  
 )
 from atlasapiclient.config import ATLASConfigFile
 from atlasapiclient.authentication import Token
@@ -95,7 +95,7 @@ class APIClient(ABC):
         self.auto_refresh_fl = auto_refresh_fl
 
         # self.headers = {'Authorization': f"Token {config['token']}"}  # Set the headers with my private token
-        self.apiURL = get_url(self.config['base_url'])  # Set the base of the url (the same for all requests)
+        self.apiURL = validate_url(self.config['base_url'])  # Set the base of the url (the same for all requests)
         # -> directs to the ATLAS transient web server
 
     @property

--- a/atlasapiclient/config.py
+++ b/atlasapiclient/config.py
@@ -1,0 +1,57 @@
+import yaml
+import os
+from typing import Dict, Any
+
+from .exceptions import ATLASAPIClientConfigError
+
+class ATLASConfigFile:
+    def __init__(self, file_path: str):
+        assert os.path.exists(file_path), f"{file_path} file does not exist"  # Check file exits
+        
+        self.file_path = file_path
+        self.contents = self._validate(self._read())
+        
+    def __getitem__(self, key: str) -> Any:
+        return self.contents[key]
+    
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.contents[key] = value
+        
+    def _read(self) -> Any:
+        try:
+            with open(self.file_path, 'r') as my_yaml_file:  # Open the file
+                contents = yaml.safe_load(my_yaml_file)
+        except yaml.YAMLError as e:
+            raise ATLASAPIClientConfigError(f"Error parsing YAML file: {e}")
+        
+        return self._validate(contents)
+    
+    def _write(self, contents: Dict[str, Any]) -> None:
+        self._validate(contents)
+        try:
+            with open(self.file_path, 'w') as my_yaml_file:
+                yaml.dump(contents, my_yaml_file)
+        except yaml.YAMLError as e:
+            raise ATLASAPIClientConfigError(f"Error writing to YAML file: {e}")
+
+    def write(self) -> None:
+        self._write(self.contents)
+    
+    def read(self) -> Dict[str, Any]:
+        self.contents = self._read()
+    
+    @staticmethod
+    def _validate(contents: Dict[str, Any]) -> None:
+        if not isinstance(contents, dict):
+            raise ATLASAPIClientConfigError("Config contents must be a dictionary")
+        
+        if not contents:
+            raise ATLASAPIClientConfigError("Config contents must not be empty")
+        
+        if 'token' not in contents:
+            raise ATLASAPIClientConfigError("Config contents must contain an 'token'")
+        
+        if 'base_url' not in contents:
+            raise ATLASAPIClientConfigError("Config contents must contain a 'base_url'")
+        
+        return contents

--- a/atlasapiclient/config.py
+++ b/atlasapiclient/config.py
@@ -6,8 +6,11 @@ from .exceptions import ATLASAPIClientConfigError
 
 class ATLASConfigFile:
     def __init__(self, file_path: str):
-        assert os.path.exists(file_path), f"{file_path} file does not exist"  # Check file exits
+        # Check that the file exists
+        if not os.path.exists(file_path):
+            ATLASAPIClientConfigError(f"{file_path} file does not exist")
         
+        # Set the file path and read the contents
         self.file_path = file_path
         self.contents = self._validate(self._read())
         
@@ -23,6 +26,8 @@ class ATLASConfigFile:
                 contents = yaml.safe_load(my_yaml_file)
         except yaml.YAMLError as e:
             raise ATLASAPIClientConfigError(f"Error parsing YAML file: {e}")
+        except FileNotFoundError as e:
+            raise ATLASAPIClientConfigError(f"Could not find file: {e}")
         
         return self._validate(contents)
     

--- a/atlasapiclient/config_files/api_config_template.yaml
+++ b/atlasapiclient/config_files/api_config_template.yaml
@@ -1,2 +1,2 @@
-token: "YOURTOKEN"
+token: "thisisntarealtokenpleaseputyourtokenhere"
 base_url: "https://<server>/api/"

--- a/atlasapiclient/config_files/api_config_template.yaml
+++ b/atlasapiclient/config_files/api_config_template.yaml
@@ -1,2 +1,2 @@
 token: "YOURTOKEN"
-base_url: "https/<server>/api/"
+base_url: "https://<server>/api/"

--- a/atlasapiclient/utils.py
+++ b/atlasapiclient/utils.py
@@ -1,5 +1,8 @@
 import pkg_resources
 import os
+import urllib
+
+from .exceptions import ATLASAPIClientError 
 
 # Useful Constants
 LIST_NAMES = "follow_up, good, possible, eyeball, attic, cv, mdwarf, pm_stars"
@@ -27,3 +30,27 @@ dict_list_id = {'garbage': [0, False],
                 'vra': [73, True],
                 'dummy': [999, True]
                 }
+
+            
+def get_url(config_val: str) -> str:
+    """Ensure that the URL is valid, using urllib, and return it"""
+    # Parse the URL into its components
+    try:
+        url_parts = urllib.parse.urlparse(config_val)
+    except Exception as e:
+        raise ATLASAPIClientError(f"Invalid URL - exception caused: {config_val}, {e}")
+    
+    # Do some validation
+    if not url_parts.scheme or not url_parts.netloc:
+        raise ATLASAPIClientError(f"Invalid URL: {config_val}")
+    elif url_parts.scheme not in ['http', 'https']:
+        raise ATLASAPIClientError(f"Invalid URL scheme: {url_parts.scheme}")
+    
+    # Add a trailing slash to the path
+    if url_parts.path:
+        if url_parts.path[-1] != '/':
+            url_parts = url_parts._replace(path=url_parts.path + '/')
+    else:
+        url_parts = url_parts._replace(path='/')
+    
+    return urllib.parse.urlunparse(url_parts)

--- a/atlasapiclient/utils.py
+++ b/atlasapiclient/utils.py
@@ -32,7 +32,7 @@ dict_list_id = {'garbage': [0, False],
                 }
 
             
-def get_url(config_val: str) -> str:
+def validate_url(config_val: str) -> str:
     """Ensure that the URL is valid, using urllib, and return it"""
     # Parse the URL into its components
     try:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,23 @@
+import os
+
+import pytest
+
+from atlasapiclient.utils import config_path
+
+@pytest.fixture()
+def config_file():
+    # Create a path to the api_config_template.yaml file in the config_files
+    return os.path.join(config_path, 'api_config_template.yaml')
+
+@pytest.fixture()
+def mock_response_200():
+    return MockResponse(200)
+
+
+class MockResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+        self.json = lambda: {'key': 'value'}
+    
+    def json(self):
+        return self.json

--- a/test/integration/test_api_read.py
+++ b/test/integration/test_api_read.py
@@ -82,13 +82,14 @@ class TestRequestCustomListsTable():
                                                                 payload={'objectid':'1103337110432157700'}
                                                                 )
         request_custom_lists.get_response()
-        assert request_custom_lists.request.status_code == 200, "Data wasn't read properly"
+        assert request_custom_lists.response.status_code == 200, "Data wasn't read properly"
+        
     def test_request_custom_list(self):
         request_custom_lists = atlasapi.client.RequestCustomListsTable(api_config_file=API_CONFIG_FILE,
                                                                 payload={'objectgroupid':'6'}
                                                                 )
         request_custom_lists.get_response()
-        assert request_custom_lists.request.status_code == 200, "Data wasn't read properly"
+        assert request_custom_lists.response.status_code == 200, "Data wasn't read properly"
 
 @pytest.mark.integration
 class TestRequestSingleSourceData():

--- a/test/integration/test_api_write.py
+++ b/test/integration/test_api_write.py
@@ -30,6 +30,7 @@ class TestWriteToVRAScores():
                                                 )
         writeto_vra.payload = {'objectid': '1132507360113744501', 'debug': 1}
         writeto_vra.get_response()
+        
     def test_send_something_from_instanciation(self):
         # TODO: IF THE OBJECT DOESN'T EXIST THEN THE API WILL STILL RETURN A 201,
         # WITH A MESSAGE PAYLOAD SAYING INFO: THE OBJECT DOES NOT EXIST

--- a/test/test_authentication.py
+++ b/test/test_authentication.py
@@ -1,0 +1,122 @@
+import getpass
+import io
+
+import pytest
+import requests
+
+from atlasapiclient.authentication import Token
+from atlasapiclient.exceptions import ATLASAPIClientAuthError
+from .conftest import MockResponse
+
+@pytest.fixture()
+def dummy_token_str():
+    return '1234567890123456789012345678901234567890'
+
+@pytest.fixture()
+def alt_dummy_token_str():
+    return '1111111111111111111111111111111111111111'
+
+@pytest.fixture()
+def token(dummy_token_str):
+    return Token(dummy_token_str)
+
+class MockAuthResponse:
+    def __init__(self, status_code, token_str):
+        self.status_code = status_code
+        self.json = lambda: {'token': token_str}
+    
+    def json(self):
+        return self.json
+
+class TestToken():
+    def test_constructor(self, dummy_token_str):
+        # 40 characters long str should work 
+        token = Token(dummy_token_str)
+        
+    @pytest.mark.parametrize("token_str, expected_exception", [
+        ("", ATLASAPIClientAuthError),
+        ("123", ATLASAPIClientAuthError),
+        ("12345678901234567890123456789012345678901", ATLASAPIClientAuthError),
+        (None, ATLASAPIClientAuthError),
+        (1, ATLASAPIClientAuthError),
+        (True, ATLASAPIClientAuthError),
+        (False, ATLASAPIClientAuthError),
+        ({"key": "value"}, ATLASAPIClientAuthError),
+        ([1, 2, 3], ATLASAPIClientAuthError),
+    ])
+    def test_constructor_bad(self, token_str, expected_exception):
+        with pytest.raises(expected_exception):
+            Token(token_str)
+            
+    def test_as_auth_header(self, token, dummy_token_str):
+        assert token.as_auth_header() == f"Token {dummy_token_str}"
+        
+    def test_as_bearer_header(self, token, dummy_token_str):
+        assert token.as_bearer_header() == f"Bearer {dummy_token_str}"
+        
+    def test_as_query_param(self, token, dummy_token_str):
+        assert token.as_query_param() == dummy_token_str
+        
+    def test_as_cookie(self, token, dummy_token_str):
+        cookie = token.as_cookie()
+        assert isinstance(cookie, dict)
+        assert "token" in cookie
+        assert token.as_cookie() == {"token": dummy_token_str}
+        
+    def test_validate(self, token, alt_dummy_token_str):
+        token.val = alt_dummy_token_str
+        token.validate()
+        assert token.val == alt_dummy_token_str
+        
+    @pytest.mark.parametrize("token_str", [
+        "12345678901234567890123456789012345678901",
+        "123456789012345678901234567890123456789",
+        "123",
+        "",
+        0,
+        True,
+        False,
+        None,
+        {"key": "value"},
+        [1, 2, 3],
+    ])
+    def test_validate_bad(self, token, token_str):
+        token.val = token_str
+        with pytest.raises(ATLASAPIClientAuthError):
+            token.validate()
+    
+    def test_refresh_200(self, monkeypatch, token, alt_dummy_token_str):
+        monkeypatch.setattr(requests, 'post', 
+                            lambda *args, **kwargs: MockAuthResponse(200, alt_dummy_token_str))
+        monkeypatch.setattr(Token, 'get_username_password', lambda _: ('username', 'password'))
+        token.refresh('http://localhost:8000/')
+        assert token.val == alt_dummy_token_str
+    
+    @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 500])
+    def test_refresh_error_codes(self, monkeypatch, token, dummy_token_str, status_code):
+        monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockResponse(status_code))
+        monkeypatch.setattr(Token, 'get_username_password', lambda _: ('username', 'password'))
+        with pytest.raises(ATLASAPIClientAuthError):
+            token.refresh('http://localhost:8000/')
+        assert token.val == dummy_token_str
+            
+    def test_refresh_error_invalid_token(self, monkeypatch, token):
+        invalid_token_str = 'invalid_token'
+        monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockAuthResponse(200, invalid_token_str))
+        monkeypatch.setattr(Token, 'get_username_password', lambda _: ('username', 'password'))
+        with pytest.raises(ATLASAPIClientAuthError):
+            token.refresh('http://localhost:8000/')
+            
+    @pytest.mark.parametrize("url", [None, 0, 1, True, False, {"key": "value"}, [1, 2, 3]])
+    def test_refresh_error_base_url(self, monkeypatch, token, url):
+        monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockAuthResponse(200, token.val))
+        monkeypatch.setattr(Token, 'get_username_password', lambda _: ('username', 'password'))
+        with pytest.raises(ATLASAPIClientAuthError):
+            token.refresh(url)
+            
+    def test_get_username_password(self, monkeypatch):
+        monkeypatch.setattr('sys.stdin', io.StringIO('username'))
+        monkeypatch.setattr(getpass, 'getpass', lambda _: 'password')
+        username, password = Token.get_username_password()
+        assert username == 'username'
+        assert password == 'password'

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -8,9 +8,10 @@ import numpy as np
 
 from atlasapiclient.client import (
     APIClient, RequestVRAScores, RequestVRAToDoList, RequestCustomListsTable,
-    RequestSingleSourceData, RequestMultipleSourceData, ConeSearch, RequestATLASIDsFromWebServerList
+    RequestSingleSourceData, RequestMultipleSourceData, ConeSearch, 
+    RequestATLASIDsFromWebServerList
 )
-from atlasapiclient.exceptions import ATLASAPIClientError
+from atlasapiclient.exceptions import ATLASAPIClientError, ATLASAPIClientConfigError
 from atlasapiclient.utils import config_path
 import atlasapiclient.client
 import atlasapiclient.utils
@@ -33,7 +34,7 @@ class TestAPIClient():
         # not present
         fake_config_file = os.path.join(config_path, 'fake_config.yaml')
         monkeypatch.setattr(atlasapiclient.client, "API_CONFIG_FILE", fake_config_file)
-        with pytest.raises(AssertionError):
+        with pytest.raises(ATLASAPIClientConfigError):
             APIClient()
         
         # Then make it a file we know exists.
@@ -81,7 +82,7 @@ class TestAPIClient():
         # Check the attributes that are set by the config file
         assert hasattr(client, 'headers')   
         assert 'Authorization' in client.headers
-        assert client.headers['Authorization'] == 'Token YOURTOKEN'
+        assert client.headers['Authorization'] == 'Token thisisntarealtokenpleaseputyourtokenhere'
         
         assert hasattr(client, 'apiURL')
         assert client.apiURL == "https://<server>/api/"

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -15,12 +15,7 @@ from atlasapiclient.exceptions import ATLASAPIClientError, ATLASAPIClientConfigE
 from atlasapiclient.utils import config_path
 import atlasapiclient.client
 import atlasapiclient.utils
-
-
-@pytest.fixture()
-def config_file():
-    # Create a path to the api_config_template.yaml file in the config_files
-    return os.path.join(config_path, 'api_config_template.yaml')
+from .conftest import MockResponse
 
 
 class TestAPIClient():
@@ -283,10 +278,10 @@ class TestRequestATLASIDsFromWebServerList:
     # TODO: add test for list that doesn't exist (have the constructor through a useful error
 
 
-class MockResponse:
-    def __init__(self, status_code):
-        self.status_code = status_code
-        self.json = lambda: {'key': 'value'}
+# class MockResponse:
+#     def __init__(self, status_code):
+#         self.status_code = status_code
+#         self.json = lambda: {'key': 'value'}
     
-    def json(self):
-        return self.json
+#     def json(self):
+#         return self.json

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -84,7 +84,7 @@ class TestAPIClient():
         assert client.headers['Authorization'] == 'Token YOURTOKEN'
         
         assert hasattr(client, 'apiURL')
-        assert client.apiURL == "https/<server>/api/"
+        assert client.apiURL == "https://<server>/api/"
 
     def test_get_response_200(self, monkeypatch, client):
         # Replace the requests.post function with a lambda that returns a MockResponse

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -57,7 +57,7 @@ class TestAPIClient():
             APIClient('test')
     
     def test_constructor_config_file_with_missing_file(self):
-        with pytest.raises(AssertionError):
+        with pytest.raises(ATLASAPIClientConfigError):
             APIClient('config-file.json')
         
     def test_contructor_config_file_with_malformed_file(self):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,38 @@
+# import __builtin__
+import os
+
+import pytest
+
+from atlasapiclient.config import ATLASConfigFile 
+from atlasapiclient.utils import config_path
+from atlasapiclient.exceptions import ATLASAPIClientConfigError
+import atlasapiclient.client
+
+class TestAPIConfigFile():
+    def test_constructor(self, config_file):
+        ATLASConfigFile(config_file)
+    
+    def test_constructor_fake(self, monkeypatch, config_file):
+        fake_config_file = os.path.join(config_path, 'fake_config.yaml')
+        monkeypatch.setattr(atlasapiclient.client, "API_CONFIG_FILE", fake_config_file)
+        with pytest.raises(ATLASAPIClientConfigError):
+            ATLASConfigFile(fake_config_file)
+            
+    def test_constructor_no_file(self):
+        with pytest.raises(ATLASAPIClientConfigError):
+            ATLASConfigFile('')
+            
+    def test_constructor_directory(self):
+        # NOTE: again, this is not necessarily the best error to be raised
+        with pytest.raises(IsADirectoryError):
+            ATLASConfigFile('test/')
+            
+    def test_read(self, config_file):
+        config = ATLASConfigFile(config_file)
+        config.read()
+        
+    # def test_write(self, monkeypatch, config_file):
+    #     config = ATLASConfigFile(config_file)
+    #     monkeypatch.setattr(__builtins__, "open", lambda x: None)
+    #     config.write()
+        

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,7 @@
 # Write tests for utils in atlasapiclient.utils
 import pytest
 
-from atlasapiclient.utils import LIST_NAMES, API_CONFIG_FILE, dict_list_id, get_url
+from atlasapiclient.utils import LIST_NAMES, API_CONFIG_FILE, dict_list_id, validate_url
 from atlasapiclient.exceptions import ATLASAPIClientError
 
 class TestUtilsTypes():
@@ -22,73 +22,73 @@ class TestUtilsTypes():
             
 class TestGetUrl():
     def test_get_url_no_path_trailing_slash(self):
-        assert get_url("http://www.google.com") == "http://www.google.com/", "get_url did not add a trailing slash"
-        assert get_url("https://www.google.com") == "https://www.google.com/", "get_url did not add a trailing slash"
-        assert get_url("http://www.google.com/") == "http://www.google.com/", "get_url added an extra trailing slash"
-        assert get_url("https://www.google.com/") == "https://www.google.com/", "get_url added an extra trailing slash"
+        assert validate_url("http://www.google.com") == "http://www.google.com/", "get_url did not add a trailing slash"
+        assert validate_url("https://www.google.com") == "https://www.google.com/", "get_url did not add a trailing slash"
+        assert validate_url("http://www.google.com/") == "http://www.google.com/", "get_url added an extra trailing slash"
+        assert validate_url("https://www.google.com/") == "https://www.google.com/", "get_url added an extra trailing slash"
     
     def test_get_url_path_trailing_slash(self):
-        assert get_url("http://www.google.com/api") == "http://www.google.com/api/", "get_url did not add a trailing slash"
-        assert get_url("https://www.google.com/api") == "https://www.google.com/api/", "get_url did not add a trailing slash"
-        assert get_url("http://www.google.com/api/") == "http://www.google.com/api/", "get_url added an extra trailing slash"
-        assert get_url("https://www.google.com/api/") == "https://www.google.com/api/", "get_url added an extra trailing slash"
+        assert validate_url("http://www.google.com/api") == "http://www.google.com/api/", "get_url did not add a trailing slash"
+        assert validate_url("https://www.google.com/api") == "https://www.google.com/api/", "get_url did not add a trailing slash"
+        assert validate_url("http://www.google.com/api/") == "http://www.google.com/api/", "get_url added an extra trailing slash"
+        assert validate_url("https://www.google.com/api/") == "https://www.google.com/api/", "get_url added an extra trailing slash"
     
     def test_get_url_invalid_scheme(self):
         # Unsupported schemes
         with pytest.raises(ATLASAPIClientError):
-            get_url("ftp://www.google.com")
+            validate_url("ftp://www.google.com")
         with pytest.raises(ATLASAPIClientError):
-            get_url("htp://www.google.com")
+            validate_url("htp://www.google.com")
             
     def test_get_url_typo_scheme(self):
         with pytest.raises(ATLASAPIClientError):
-            get_url("http:/www.google.com")
+            validate_url("http:/www.google.com")
         with pytest.raises(ATLASAPIClientError):
-            get_url("http//www.google.com")
+            validate_url("http//www.google.com")
             
     def test_get_url_typo_scheme_trailing_slash(self):
         with pytest.raises(ATLASAPIClientError):
-            get_url("http:/www.google.com/")
+            validate_url("http:/www.google.com/")
         with pytest.raises(ATLASAPIClientError):
-            get_url("http//www.google.com/")
+            validate_url("http//www.google.com/")
 
     def test_get_url(self):
-        get_url("http://www.google.com") # Should not raise an error
-        get_url("https://www.google.com") # Should not raise an error
+        validate_url("http://www.google.com") # Should not raise an error
+        validate_url("https://www.google.com") # Should not raise an error
         
     def test_get_url_typo_scheme_path(self):
         with pytest.raises(ATLASAPIClientError):
-            get_url("http:/www.google.com/api")
+            validate_url("http:/www.google.com/api")
         with pytest.raises(ATLASAPIClientError):
-            get_url("http//www.google.com/api")
+            validate_url("http//www.google.com/api")
 
     def test_get_url_typo_scheme_path_trailing_slash(self):
         with pytest.raises(ATLASAPIClientError):
-            get_url("http:/www.google.com/api/")
+            validate_url("http:/www.google.com/api/")
         with pytest.raises(ATLASAPIClientError):
-            get_url("http//www.google.com/api/")
+            validate_url("http//www.google.com/api/")
     
     def test_get_url_invalid_netloc(self):
         with pytest.raises(ATLASAPIClientError):
-            get_url("http://")
+            validate_url("http://")
         with pytest.raises(ATLASAPIClientError):
-            get_url("https://")
+            validate_url("https://")
         with pytest.raises(ATLASAPIClientError):
-            get_url("http:///")
+            validate_url("http:///")
         with pytest.raises(ATLASAPIClientError):
-            get_url("https:///")
+            validate_url("https:///")
 
     def test_get_url_invalid_netloc_path(self):
         with pytest.raises(ATLASAPIClientError):
-            get_url("http:///api")
+            validate_url("http:///api")
         with pytest.raises(ATLASAPIClientError):
-            get_url("https:///api")
+            validate_url("https:///api")
         with pytest.raises(ATLASAPIClientError):
-            get_url("http:///api/")
+            validate_url("http:///api/")
         with pytest.raises(ATLASAPIClientError):
-            get_url("https:///api/")
+            validate_url("https:///api/")
     
     @pytest.mark.parametrize("url", [1, 1.0, True, False, [], {}, (), None])
     def test_get_url_invalid_type(self, url):
         with pytest.raises(ATLASAPIClientError):
-            get_url(url)
+            validate_url(url)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,8 @@
 # Write tests for utils in atlasapiclient.utils
-
 import pytest
-from atlasapiclient.utils import LIST_NAMES, API_CONFIG_FILE, dict_list_id
+
+from atlasapiclient.utils import LIST_NAMES, API_CONFIG_FILE, dict_list_id, get_url
+from atlasapiclient.exceptions import ATLASAPIClientError
 
 class TestUtilsTypes():
     def test_LIST_NAMES(self):
@@ -20,4 +21,75 @@ class TestUtilsTypes():
             assert isinstance(items[1][0], int), "The first element in the values of dict_list_id is not an integer"
             assert isinstance(items[1][1], bool), "The second element in the values of dict_list_id is not a boolean"
             
-# TODO: Write tests for the functions in atlasapiclient.utils when they appear
+class TestGetUrl():
+    def test_get_url_no_path_trailing_slash(self):
+        assert get_url("http://www.google.com") == "http://www.google.com/", "get_url did not add a trailing slash"
+        assert get_url("https://www.google.com") == "https://www.google.com/", "get_url did not add a trailing slash"
+        assert get_url("http://www.google.com/") == "http://www.google.com/", "get_url added an extra trailing slash"
+        assert get_url("https://www.google.com/") == "https://www.google.com/", "get_url added an extra trailing slash"
+    
+    def test_get_url_path_trailing_slash(self):
+        assert get_url("http://www.google.com/api") == "http://www.google.com/api/", "get_url did not add a trailing slash"
+        assert get_url("https://www.google.com/api") == "https://www.google.com/api/", "get_url did not add a trailing slash"
+        assert get_url("http://www.google.com/api/") == "http://www.google.com/api/", "get_url added an extra trailing slash"
+        assert get_url("https://www.google.com/api/") == "https://www.google.com/api/", "get_url added an extra trailing slash"
+    
+    def test_get_url_invalid_scheme(self):
+        # Unsupported schemes
+        with pytest.raises(ATLASAPIClientError):
+            get_url("ftp://www.google.com")
+        with pytest.raises(ATLASAPIClientError):
+            get_url("htp://www.google.com")
+            
+    def test_get_url_typo_scheme(self):
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http:/www.google.com")
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http//www.google.com")
+            
+    def test_get_url_typo_scheme_trailing_slash(self):
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http:/www.google.com/")
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http//www.google.com/")
+
+    def test_get_url(self):
+        get_url("http://www.google.com") # Should not raise an error
+        get_url("https://www.google.com") # Should not raise an error
+        
+    def test_get_url_typo_scheme_path(self):
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http:/www.google.com/api")
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http//www.google.com/api")
+
+    def test_get_url_typo_scheme_path_trailing_slash(self):
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http:/www.google.com/api/")
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http//www.google.com/api/")
+    
+    def test_get_url_invalid_netloc(self):
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http://")
+        with pytest.raises(ATLASAPIClientError):
+            get_url("https://")
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http:///")
+        with pytest.raises(ATLASAPIClientError):
+            get_url("https:///")
+
+    def test_get_url_invalid_netloc_path(self):
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http:///api")
+        with pytest.raises(ATLASAPIClientError):
+            get_url("https:///api")
+        with pytest.raises(ATLASAPIClientError):
+            get_url("http:///api/")
+        with pytest.raises(ATLASAPIClientError):
+            get_url("https:///api/")
+    
+    @pytest.mark.parametrize("url", [1, 1.0, True, False, [], {}, (), None])
+    def test_get_url_invalid_type(self, url):
+        with pytest.raises(ATLASAPIClientError):
+            get_url(url)


### PR DESCRIPTION
Adds functionality for automatically refreshing tokens when the one used is returned via a 401. Stops the workflow and asks for a username and password, which will kill automatic workflows but going to a access+refresh token situation didn't seem like a better option – I have added a flag for turning off auto-refresh onto the client constructor so this can be deactivated if necessary! The refreshment automatically updates the config file with the new token, I'm not 100% how this would work with mulitple clients open at teh same time though - we might want the auto-refresh to first check the config file to see if the token has been updated and then do a refreshment call? Will have a think abou this...

I've also added a method on the client (`update_token()`)  so that users can manually refresh their token without intervention. 

These changes necessitated a bit of a refactor, so 'authentication.py' and 'config.py' now handle the token and the config file respectively. Have a look and let me know if you think it all makes sense, very happy to go through it in person of course! 