### PR TITLE
Fixes Issue33 - import calls don't reappripriate the name atlasapiclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ variable in the ``atlasapiclient/utils.py file``.
 
 For example:
 ```python   
-from atlasapiclient import client as atlasapiclient
+from atlasapiclient import client as atlasapi
 
 client = atlasapiclient.APIClient()
 client.refresh_token()
@@ -84,9 +84,9 @@ cp api_config_template.yaml api_config_MINE.yaml
 ### Cone Search
 
 ``` python
-from atlasapiclient import client as atlasapiclient
+from atlasapiclient import client as atlasapi
 
-client = atlasapiclient.ConeSearch(payload={'ra': 150,
+client = atlasapi.ConeSearch(payload={'ra': 150,
                                             'dec': 60,
                                             'radius': 60,
                                             'requestType': 'nearest'},
@@ -99,10 +99,10 @@ client = atlasapiclient.ConeSearch(payload={'ra': 150,
 To get the data:
 
 ```python
-from atlasapiclient import client as atlasapiclient
+from atlasapiclient import client as atlasapi
 
 atlas_id = '1161600211221604900'
-client = atlasapiclient.RequestSingleSourceData(atlas_id=atlas_id, get_response=True)
+client = atlasapi.RequestSingleSourceData(atlas_id=atlas_id, get_response=True)
 ```
 
 To extract the light curve data from the JSON:
@@ -151,9 +151,9 @@ ax.legend()
 ### Data for Multiple Objects
 
 ```python
-from atlasapiclient import client as atlasapiclient
+from atlasapiclient import client as atlasapi
 
-client = atlasapiclient.RequestMultipleSourceData(array_ids=YOUR_LIST_OF_IDS, mjdthreshold = LOWER_MJD_THRESHOLD)
+client = atlasapi.RequestMultipleSourceData(array_ids=YOUR_LIST_OF_IDS, mjdthreshold = LOWER_MJD_THRESHOLD)
 client.chunk_get_response() # Chunks the list of IDs into a bunch of payloads and colates the responses.
 ```
 

--- a/atlasapiclient/authentication.py
+++ b/atlasapiclient/authentication.py
@@ -94,9 +94,9 @@ class Token():
             if 'non_field_errors' in response_data:
                 raise ATLASAPIClientAuthError(f"Failed to refresh token: {response_data['non_field_errors']}")
             elif 'username' in response_data:
-                raise ATLASAPIClientAuthError(f"Failed to refresh token: no username was provided")
+                raise ATLASAPIClientAuthError("Failed to refresh token: no username was provided")
             elif 'password' in response_data:
-                raise ATLASAPIClientAuthError(f"Failed to refresh token: no password was provided")
+                raise ATLASAPIClientAuthError("Failed to refresh token: no password was provided")
             else:
                 raise ATLASAPIClientAuthError(f"Failed to refresh token, unspecified 400 error: {response_data}")
         else:

--- a/atlasapiclient/client.py
+++ b/atlasapiclient/client.py
@@ -24,9 +24,7 @@ import random
 
 import requests
 import numpy as np
-from pkg_resources import non_empty_lines
 from tqdm import tqdm
-import pandas as pd
 
 from atlasapiclient.exceptions import (
     ATLASAPIClientError, 

--- a/atlasapiclient/client.py
+++ b/atlasapiclient/client.py
@@ -563,9 +563,9 @@ class RequestMultipleSourceData(APIClient):
         assert output_dir is not None, "You need to provide an output directory"
         assert self.response is not None, "You need to run get_response() before saving"
 
-        for i in tqdm(range(len(self.response))):
-            with open(f"{output_dir}{str(self.response[i]['object']['id'])}.json", "w") as outfile:
-                json.dump(self.response[i], outfile)
+        for i in tqdm(range(len(self.response_data))):
+            with open(f"{output_dir}{str(self.response_data[i]['object']['id'])}.json", "w") as outfile:
+                json.dump(self.response_data[i], outfile)
 
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../../'))
 
-import atlasapiclient
 from atlasapiclient import __version__
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/users.rst
+++ b/docs/source/users.rst
@@ -42,8 +42,7 @@ For example:
 
 .. code-block:: python
 
-   from atlasapiclient import client as atlaspaiclient
-
+   from atlasapiclient import client as atlasapi
    client = atlaspaiclient.APIClient()
    client.refresh_token()
 
@@ -65,9 +64,9 @@ The cone search requires **four parameters**:
 
 .. code-block:: python
 
-    from atlasapiclient import client as atlaspaiclient
+    from atlasapiclient import client as atlasapi
 
-    client = atlaspaiclient.ConeSearch(payload={'ra': 150,
+    client = atlasapi.ConeSearch(payload={'ra': 150,
                                                 'dec': 60,
                                                 'radius': 60,
                                                 'requestType': 'nearest'},
@@ -83,10 +82,10 @@ Get the data
 --------------
 .. code-block:: python
 
-   from atlasapiclient import client as atlaspaiclient
+   from atlasapiclient import client as atlasapi
 
    atlas_id = '1161600211221604900'
-   client = atlaspaiclient.RequestSingleSourceData(atlas_id=atlas_id, get_response=True)
+   client = atlasapi.RequestSingleSourceData(atlas_id=atlas_id, get_response=True)
 
 
 Note: Here we don't parse the config file because we assume you have named yours  `api_config_MINE.yaml`.
@@ -155,9 +154,9 @@ To handle this, there is a class to chunk stuff for you:
 
 .. code-block:: python
 
-   from atlasapiclient import client as atlaspaiclient
+   from atlasapiclient import client as atlasapi
 
-   client = RequestMultipleSourceData(atlas_ids=YOUR_LIST_OF_IDS, mjdthreshold = LOWER_MJD_THRESHOLD)
+   client = atlasapi.RequestMultipleSourceData(atlas_ids=YOUR_LIST_OF_IDS, mjdthreshold = LOWER_MJD_THRESHOLD)
    client.chunk_get_response() # Chunks the list of IDs into a bunch of payloads and colates the responses.
 
 You can then get the data just as you would for a single object.

--- a/test/integration/test_api_write.py
+++ b/test/integration/test_api_write.py
@@ -1,7 +1,6 @@
 """
 These tests only work if you have a token for the ATLAS api. 
 """
-import pkg_resources
 
 import pytest
 import numpy as np

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,6 +1,5 @@
 # Write tests for the functions in atlasapiclient.client
 import os
-from yaml.scanner import ScannerError
 
 import pytest
 import requests

--- a/test/test_importlib.py
+++ b/test/test_importlib.py
@@ -1,4 +1,3 @@
-import pytest
 
 def test_init():
-    import atlasapiclient
+    pass


### PR DESCRIPTION
All references such as 

```
from atlasapiclient import client as atlasapiclient
```

where changed to 

```
from atlasapiclient import client as atlasapi
```