### PR TITLE
Fix/issue 42 43 write response bugs

### DIFF
--- a/atlasapiclient/client.py
+++ b/atlasapiclient/client.py
@@ -729,12 +729,19 @@ class WriteToCustomList(APIClient):
                             'objectgroupid': self.object_group_id
                            }
 
-        if get_response: self.get_response()
+            # Fixed by Claude for issue #43 (2026-06-17): only fire here when
+            # chunking wasn't already used above, otherwise this re-submits
+            # the last chunk's payload a second time.
+            if get_response: self.get_response()
 
     def chunk_get_response_quiet(self):
         """Chunks the request in groups of 100 so don't get timed out by the server. No progress bar."""
         # Split array_ids into chunks of 100
         chunks = [self.array_ids[i:i + 100] for i in range(0, len(self.array_ids), 100)]
+
+        # Fixed by Claude for issue #43 (2026-06-17): response_data must be
+        # initialized to a list before extending it, as RemoveFromCustomList does.
+        self.response_data = []
 
         # Iterate over each chunk and make separate requests
         for chunk in chunks:

--- a/atlasapiclient/client.py
+++ b/atlasapiclient/client.py
@@ -152,11 +152,19 @@ class APIClient(ABC):
             else:
                 return self.response.json()
 
+        # Fixed by Claude for issue #42 (2026-06-17): 201/204 branches now
+        # return data when inplace=False, matching the 200 branch.
         elif self.response.status_code == 201:  # Status if WRITE request went well
-            self.response_data = self.response.json()
+            if inplace:
+                self.response_data = self.response.json()
+            else:
+                return self.response.json()
 
         elif self.response.status_code == 204:  # Status if DELETE request went well
-            self.response_data = 'No Content'  # can't do .json() on a 204 response
+            if inplace:
+                self.response_data = 'No Content'  # can't do .json() on a 204 response
+            else:
+                return 'No Content'
 
         # If the request is bad, we check the response and raise the apprpriate error
         elif self.response.status_code == 401 and 'detail' in self.response.json():  # Status if the request is bad

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -119,7 +119,25 @@ class TestAPIClient():
         monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockResponse(400))
         with pytest.raises(ATLASAPIClientError):
             client.get_response()
-            
+
+    # Added by Claude to fix issue #42 (2026-06-17)
+    def test_get_response_201_inplace_false(self, monkeypatch, client):
+        # WRITE success (201) with inplace=False must return the data, same as 200 does
+        monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockResponse(201))
+
+        response = client.get_response(inplace=False)
+
+        assert response is not None
+        assert response == client.response.json()
+
+    def test_get_response_204_inplace_false(self, monkeypatch, client):
+        # DELETE success (204) with inplace=False must return the data, same as 200 does
+        monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockResponse(204))
+
+        response = client.get_response(inplace=False)
+
+        assert response == 'No Content'
+
 
 class TestConeSearch:
     def test_constructor(self, monkeypatch, config_file):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -7,7 +7,8 @@ import numpy as np
 
 from atlasapiclient.client import (
     APIClient, RequestVRAScores, RequestVRAToDoList, RequestCustomListsTable,
-    RequestSingleSourceData, RequestMultipleSourceData, ConeSearch, 
+    RequestSingleSourceData, RequestMultipleSourceData, ConeSearch,
+    WriteToCustomList,
 )
 from atlasapiclient.exceptions import (
     ATLASAPIClientError, 
@@ -299,8 +300,36 @@ class TestRequestMultipleSourceData:
         with pytest.raises(AssertionError):
             RequestMultipleSourceData(api_config_file=config_file, array_ids=atlas_ids)
     
-    # TODO: write tests for the chunk_get_response methods and the 
-    # save_response_to_json method 
+    # TODO: write tests for the chunk_get_response methods and the
+    # save_response_to_json method
+
+
+class TestWriteToCustomList:
+    # Added by Claude to fix issue #43 (2026-06-17)
+    def test_chunk_get_response_quiet_initializes_response_data(self, monkeypatch, config_file):
+        monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockResponse(201))
+        atlas_ids = np.array([str(i) for i in range(150)])  # >100 -> triggers chunking
+
+        client = WriteToCustomList(api_config_file=config_file, array_ids=atlas_ids,
+                                    list_name='mookodi')
+
+        assert isinstance(client.response_data, list)
+
+    def test_get_response_true_does_not_double_fire_last_chunk(self, monkeypatch, config_file):
+        call_count = {'n': 0}
+
+        def fake_post(*args, **kwargs):
+            call_count['n'] += 1
+            return MockResponse(201)
+
+        monkeypatch.setattr(requests, 'post', fake_post)
+        atlas_ids = np.array([str(i) for i in range(150)])  # 2 chunks: 100 + 50
+
+        WriteToCustomList(api_config_file=config_file, array_ids=atlas_ids,
+                           list_name='mookodi', get_response=True)
+
+        # One POST per chunk only - get_response=True must not re-fire the last chunk
+        assert call_count['n'] == 2
 
 
 class TestRequestATLASIDsFromWebServerList:


### PR DESCRIPTION
closes issue #42 
closes issue #43

### Issue 42

This should fix the issue I had with batching the write responses as the codes 201 and 204 (write and delete) did not have conditions for the `inplace` option, so it would have returned none.

The relevant views in the django API are ``TcsObjectGroupsView`` (add) and ``TcsObjectGroupsDeleteView`` (delete) which do have 201 and 204 status code handling.

### Issue 43
`response_data` was not instanciated so it was `None` not `[]` - that is why chunking was broken! That is because the chunking logic is to ``extend`` to a list. If instanciation is None, append can't work. 
 Also was sending response twice if ``get_response = True`` option was chosen and we were batching. 

### Note - difference between append and extend:

lst = [1, 2]
lst.extend([3, 4])   # [1, 2, 3, 4]
lst.append([5, 6])   # [1, 2, 3, 4, [5, 6]]
