### PR TITLE
Upgraded Client to use the new API filtering capabilities on Object Lists

### DIFF
--- a/atlasapiclient/client.py
+++ b/atlasapiclient/client.py
@@ -31,9 +31,10 @@ from atlasapiclient.exceptions import (
     ATLASAPIClientArgumentWarning,
 )
 from atlasapiclient.utils import (
-    dict_list_id, 
-    API_CONFIG_FILE, 
-    validate_url,  
+    dict_list_id,
+    API_CONFIG_FILE,
+    validate_url,
+    VALID_SHERLOCK_CLASSES,
 )
 from atlasapiclient.config import ATLASConfigFile
 from atlasapiclient.authentication import Token
@@ -433,7 +434,10 @@ class RequestATLASIDsFromWebServerList(APIClient):
         ra_gte, ra_lte, dec_gte, dec_lte: float
             Optional lower/upper bounds on RA/Dec.
         sherlock_class: str
-            Optional exact-match filter on Sherlock classification.
+            Optional exact-match filter on Sherlock classification. Valid values are
+            in `atlasapiclient.utils.VALID_SHERLOCK_CLASSES`
+            ('ORPHAN', 'SN', 'NT', 'VS', 'CV', 'BS', 'UNCLEAR', 'HPM'); anything else
+            raises an `ATLASAPIClientArgumentWarning`.
         spec_type: str
             Optional exact-match filter on spectroscopic classification.
 
@@ -468,6 +472,14 @@ class RequestATLASIDsFromWebServerList(APIClient):
             'spec_type': spec_type,
         }
         self.payload.update({k: v for k, v in filters.items() if v is not None})
+
+        if sherlock_class is not None and sherlock_class not in VALID_SHERLOCK_CLASSES:
+            warnings.warn(
+                f"'{sherlock_class}' is not a known Sherlock classification "
+                f"({', '.join(VALID_SHERLOCK_CLASSES)}) - the request will "
+                "likely return no results.",
+                ATLASAPIClientArgumentWarning
+            )
 
         if get_response: self.get_response()
 

--- a/atlasapiclient/client.py
+++ b/atlasapiclient/client.py
@@ -397,6 +397,16 @@ class RequestATLASIDsFromWebServerList(APIClient):
                  list_name: str,
                  get_response: bool = True,
                  api_config_file: str = None,
+                 vra_gte: float = None,
+                 vra_lte: float = None,
+                 rb_pix_gte: float = None,
+                 rb_pix_lte: float = None,
+                 ra_gte: float = None,
+                 ra_lte: float = None,
+                 dec_gte: float = None,
+                 dec_lte: float = None,
+                 sherlock_class: str = None,
+                 spec_type: str = None,
                  **kwargs
                  ):
         """READ - Get all the ATLAS\_IDs from a given list on the ATLAS Transient Web Server
@@ -416,6 +426,16 @@ class RequestATLASIDsFromWebServerList(APIClient):
             If True, will get the response on instanciation
         api_config_file: str
             By default will use you api_config_MINE.yaml file.
+        vra_gte, vra_lte: float
+            Optional lower/upper bounds on VRA score.
+        rb_pix_gte, rb_pix_lte: float
+            Optional lower/upper bounds on RB Pix score.
+        ra_gte, ra_lte, dec_gte, dec_lte: float
+            Optional lower/upper bounds on RA/Dec.
+        sherlock_class: str
+            Optional exact-match filter on Sherlock classification.
+        spec_type: str
+            Optional exact-match filter on spectroscopic classification.
 
         Notes
         -------
@@ -434,6 +454,20 @@ class RequestATLASIDsFromWebServerList(APIClient):
         self.url = self.apiURL + 'objectlist/'
         self.payload = {'objectlistid': self.dict_list_id[self.list_name][0],
                         'getcustomlist': self.dict_list_id[self.list_name][1]}
+
+        filters = {
+            'vra_gte': vra_gte,
+            'vra_lte': vra_lte,
+            'rb_pix_gte': rb_pix_gte,
+            'rb_pix_lte': rb_pix_lte,
+            'ra_gte': ra_gte,
+            'ra_lte': ra_lte,
+            'dec_gte': dec_gte,
+            'dec_lte': dec_lte,
+            'sherlock_class': sherlock_class,
+            'spec_type': spec_type,
+        }
+        self.payload.update({k: v for k, v in filters.items() if v is not None})
 
         if get_response: self.get_response()
 

--- a/atlasapiclient/utils.py
+++ b/atlasapiclient/utils.py
@@ -5,6 +5,7 @@ from .exceptions import ATLASAPIClientError
 
 # Useful Constants
 LIST_NAMES = "follow_up, good, possible, eyeball, attic, cv, mdwarf, pm_stars"
+VALID_SHERLOCK_CLASSES = ('ORPHAN', 'SN', 'NT', 'VS', 'CV', 'BS', 'UNCLEAR', 'HPM')
 config_path = Path(__file__).parent / 'config_files'
 
 # NOTE: We might want to consider changing the name of the config file

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,10 @@ exclude_patterns = []
 html_theme = 'sphinx_book_theme'
 html_static_path = ['_static']
 html_logo='_static/logo.png'
-html_theme_options = {"**": ["sbt-sidebar-nav.html"],
+html_theme_options = {
   "show_toc_level": 4,
   "show_navbar_depth": 4,
+}
+html_sidebars = {
+  "**": ["sbt-sidebar-nav.html"],
 }

--- a/docs/source/users.rst
+++ b/docs/source/users.rst
@@ -183,7 +183,7 @@ Make a Neat Plot
    AT 2018 cow lightcurve
 
 Get Data for Multiple objects
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to query the ATLAS API for multiple objects you're going to encounter the rate limit, which is 100 per query.
 To handle this, there is a class to chunk stuff for you:
@@ -198,6 +198,52 @@ To handle this, there is a class to chunk stuff for you:
 You can then get the data just as you would for a single object.
 
 
+Get IDs from a Custom or Followup List
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To get all the ATLAS IDs currently on one of the web server's lists (e.g. ``eyeball``, ``good``, ``attic``,
+your own custom list, ...) use `RequestATLASIDsFromWebServerList`:
+
+.. code-block:: python
+
+   from atlasapiclient import client as atlasapi
+
+   client = atlasapi.RequestATLASIDsFromWebServerList(list_name='eyeball')
+   client.atlas_id_list_str  # list of ATLAS IDs as strings
+
+See `atlasapiclient.utils.dict_list_id` for the full set of valid ``list_name`` values.
+
+**Filtering the list server-side**
+
+If you only need a subset of a list, you can narrow the request at the API level instead of fetching
+everything and filtering client-side. This is both faster and lighter on the server, especially for
+large lists like ``eyeball``. The optional filter arguments are:
+
+* ``vra_gte`` / ``vra_lte`` -- lower/upper bound on VRA score
+* ``rb_pix_gte`` / ``rb_pix_lte`` -- lower/upper bound on RB Pix score
+* ``ra_gte`` / ``ra_lte`` -- lower/upper bound on RA
+* ``dec_gte`` / ``dec_lte`` -- lower/upper bound on Dec
+* ``sherlock_class`` -- exact match on Sherlock classification. Valid values are
+  ``ORPHAN``, ``SN``, ``NT``, ``VS``, ``CV``, ``BS``, ``UNCLEAR``, ``HPM`` -- anything
+  else raises an `ATLASAPIClientArgumentWarning`
+* ``spec_type`` -- exact match on spectroscopic classification
+
+.. code-block:: python
+
+   client = atlasapi.RequestATLASIDsFromWebServerList(
+       list_name='eyeball',
+       vra_gte=9.0,
+       dec_lte=10.0,
+   )
+
+.. tip::
+   **Can I exclude a value instead of matching it?** No -- ``sherlock_class`` and ``spec_type`` are
+   exact-match filters only, there is no "not equal to" option server-side. If your logic needs to
+   *exclude* one particular class (e.g. everything except ``'ORPHAN'``) rather than match one, you'll
+   still need to fetch the (now smaller, thanks to the other filters) candidate set and do that check
+   client-side.
+
+
 Data Structure and other bits of data
 =======================================
 
@@ -209,7 +255,7 @@ Here is a couple of handy recipes...
 
 
 Getting the Sherlock crossmatches
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------
 The first crossmatch (if any) is a merged entry which cherry picks the best information from all catalogues (so if a galaxy has info in 3 catalogues it will be cross matched 3 times and the info from these catalogues will appear as separate entries in our list of dictionaries - the first entry in the list will be the combination of all the best info in those 3 entries)
 The following entries are the individual crossmatches.
 
@@ -219,7 +265,7 @@ The following entries are the individual crossmatches.
 
 
 Is that ATLAS\_ID object in TNS?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------
 You can check the crossmatches using:
 
 .. code-block:: python

--- a/test/integration/test_api_write.py
+++ b/test/integration/test_api_write.py
@@ -112,5 +112,5 @@ class TestWriteRemoveCustomList():
                                                  list_name='dummy',
                                                  get_response=True,
                                                  )
-        assert writeto_vra.response_data[0]['info'] == 'Object does not exist.', ("We are not catching the bad list "
+        assert writeto_vra.response_data[0]['info'] == 'Object group ID does not exist.', ("We are not catching the bad list "
                                                                                   "number server side")

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -8,7 +8,7 @@ import numpy as np
 from atlasapiclient.client import (
     APIClient, RequestVRAScores, RequestVRAToDoList, RequestCustomListsTable,
     RequestSingleSourceData, RequestMultipleSourceData, ConeSearch,
-    WriteToCustomList, RemoveFromCustomList,
+    WriteToCustomList, RemoveFromCustomList, RequestATLASIDsFromWebServerList,
 )
 from atlasapiclient.exceptions import (
     ATLASAPIClientError, 
@@ -350,12 +350,40 @@ class TestRemoveFromCustomList:
 
 
 class TestRequestATLASIDsFromWebServerList:
-    def test_constructor(self, config_file):
-        #RequestATLASIDsFromWebServerList(api_config_file=config_file,
-        #                            list_name='eyeball',
-        #                           get_response=True
-        #                          )
-        pass
+    def test_constructor(self, monkeypatch, config_file):
+        monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockResponse(200))
+        client = RequestATLASIDsFromWebServerList(api_config_file=config_file,
+                                                    list_name='eyeball',
+                                                    get_response=True
+                                                    )
+        assert client.payload == {'objectlistid': client.dict_list_id['eyeball'][0],
+                                   'getcustomlist': client.dict_list_id['eyeball'][1]}
+
+    def test_payload_without_filters_omits_filter_keys(self, monkeypatch, config_file):
+        monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockResponse(200))
+        client = RequestATLASIDsFromWebServerList(api_config_file=config_file,
+                                                    list_name='eyeball',
+                                                    get_response=False
+                                                    )
+        assert 'vra_gte' not in client.payload
+        assert 'dec_lte' not in client.payload
+        assert 'sherlock_class' not in client.payload
+
+    def test_payload_includes_only_provided_filters(self, monkeypatch, config_file):
+        monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockResponse(200))
+        client = RequestATLASIDsFromWebServerList(api_config_file=config_file,
+                                                    list_name='eyeball',
+                                                    get_response=False,
+                                                    vra_gte=9.0,
+                                                    dec_lte=10.0,
+                                                    sherlock_class='SN'
+                                                    )
+        assert client.payload['vra_gte'] == 9.0
+        assert client.payload['dec_lte'] == 10.0
+        assert client.payload['sherlock_class'] == 'SN'
+        assert 'vra_lte' not in client.payload
+        assert 'ra_gte' not in client.payload
+
     # TODO: add test for list that doesn't exist (have the constructor through a useful error
 
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -384,6 +384,24 @@ class TestRequestATLASIDsFromWebServerList:
         assert 'vra_lte' not in client.payload
         assert 'ra_gte' not in client.payload
 
+    def test_valid_sherlock_class_raises_no_warning(self, monkeypatch, config_file, recwarn):
+        monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockResponse(200))
+        RequestATLASIDsFromWebServerList(api_config_file=config_file,
+                                          list_name='eyeball',
+                                          get_response=False,
+                                          sherlock_class='SN'
+                                          )
+        assert len(recwarn) == 0
+
+    def test_invalid_sherlock_class_raises_warning(self, monkeypatch, config_file):
+        monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: MockResponse(200))
+        with pytest.warns(ATLASAPIClientArgumentWarning):
+            RequestATLASIDsFromWebServerList(api_config_file=config_file,
+                                              list_name='eyeball',
+                                              get_response=False,
+                                              sherlock_class='GALAXY'
+                                              )
+
     # TODO: add test for list that doesn't exist (have the constructor through a useful error
 
 


### PR DESCRIPTION
Can now filter better in `atlasapi.RequestATLASIDsFromWebServerList`

```
   vra_gte / vra_lte – lower/upper bound on VRA score

    rb_pix_gte / rb_pix_lte – lower/upper bound on RB Pix score

    ra_gte / ra_lte – lower/upper bound on RA

    dec_gte / dec_lte – lower/upper bound on Dec

    sherlock_class – exact match on Sherlock classification. Valid values are ORPHAN, SN, NT, VS, CV, BS, UNCLEAR, HPM – anything else raises an ATLASAPIClientArgumentWarning

    spec_type – exact match on spectroscopic classification
```

Also updated the documentation to reflect that. 